### PR TITLE
Pyrefly 1.0.0 and plugin fixes

### DIFF
--- a/pants-plugins/experimental/pyrefly/BUILD
+++ b/pants-plugins/experimental/pyrefly/BUILD
@@ -1,7 +1,22 @@
 # Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources()
+python_sources(
+    name="pyrefly",
+    resolve="pants-plugins",
+)
+
+python_tests(
+    name="tests",
+    resolve="pants-plugins",
+    dependencies=[
+        ":pyrefly",
+        "pants-plugins:pants",
+    ],
+    overrides={
+        "rules_integration_test.py": {"timeout": 240},
+    },
+)
 
 python_distribution(
     name="pyrefly-dist",

--- a/pants-plugins/experimental/pyrefly/CHANGELOG.md
+++ b/pants-plugins/experimental/pyrefly/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+- Upgrade default Pyrefly version to 1.0.0 with official GitHub release binaries.
+- Fix sandbox import resolution by mounting the PEX venv via `append_only_caches`.
+- Inject Pants source roots as `--search-path` so users need not hard-code them in `pyproject.toml`.
+- Fix a typo in the rule description: "Pyreflypecheck using Pyrefly" -> "Typecheck using Pyrefly"
+
 ## [0.0.1] - 2026-01-10
 
 First release

--- a/pants-plugins/experimental/pyrefly/README.md
+++ b/pants-plugins/experimental/pyrefly/README.md
@@ -4,7 +4,9 @@ This plugin provides a Pants `check` backend using [Pyrefly](https://github.com/
 
 ## Installation
 
-This plugin was tested on Python 3.11 and Pants 2.31.0.dev3.
+This plugin was tested on Python 3.11+ and Pants 2.33.0.dev3 and 2.32.0.
+
+The plugin ships Pyrefly **1.0.0** from the [official GitHub releases](https://github.com/facebook/pyrefly/releases). Pants automatically passes your configured `[source].root_patterns` to Pyrefly as `--search-path`, so you typically do not need a `search-path` entry in `[tool.pyrefly]`.
 
 Add the following to your `pants.toml` file:
 

--- a/pants-plugins/experimental/pyrefly/register.py
+++ b/pants-plugins/experimental/pyrefly/register.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from experimental.pyrefly.rules import rules as pyrefly_rules
+from experimental.pyrefly.skip_field import rules as skip_field_rules
+from experimental.pyrefly.subsystems import rules as subsystem_rules
 from pants.engine.rules import Rule
 from pants.engine.unions import UnionRule
 
 
 def rules() -> Iterable[Rule | UnionRule]:
-    return (*pyrefly_rules(),)
+    return (*pyrefly_rules(), *subsystem_rules(), *skip_field_rules())

--- a/pants-plugins/experimental/pyrefly/rules.py
+++ b/pants-plugins/experimental/pyrefly/rules.py
@@ -36,7 +36,7 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     prepare_python_sources,
 )
-from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
+from pants.core.goals.check import CheckRequest, CheckResult, CheckResults, CheckSubsystem
 from pants.core.util_rules import config_files
 from pants.core.util_rules.config_files import find_config_file
 from pants.core.util_rules.external_tool import download_external_tool
@@ -107,6 +107,8 @@ async def pyrefly_typecheck_partition(
     pyrefly: Pyrefly,
     platform: Platform,
     pex_environment: PexEnvironment,
+    check_subsystem: CheckSubsystem,
+    python_setup: PythonSetup,
 ) -> CheckResult:
     pyrefly_tool, config_files, roots_sources, transitive_sources, requirements_pex = await concurrently(
         download_external_tool(pyrefly.get_request(platform)),
@@ -125,8 +127,7 @@ async def pyrefly_typecheck_partition(
         ),
     )
 
-    # Create a venv with the 3rd-party requirements and let Pyrefly know about it using `--venv`
-    complete_pex_env = pex_environment.in_workspace()
+    complete_pex_env = pex_environment.in_sandbox(working_directory=None)
     requirements_venv_pex = await create_venv_pex(
         VenvPexRequest(
             PexRequest(
@@ -172,18 +173,20 @@ async def pyrefly_typecheck_partition(
     # TODO: If finding the minimum failed, just arbitrarily hardcoded it to 3.10...
     python_version = (
         partition.interpreter_constraints.minimum_python_version(
-            ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+            python_setup.interpreter_versions_universe
         )
         or "3.10"
     )
-    # TODO: Handle this properly, checking out the various ways we can set the correct python version from config, pants, universe, etc
 
+    search_path_args = tuple(
+        f"--search-path={source_root}" for source_root in transitive_sources.source_roots
+    )
     TODO_DUMP_CONFIG = False
     initial_args = (
         "check" if not TODO_DUMP_CONFIG else "dump-config",
         f"--python-version={python_version}",
-        # TODO: This is greasy... Also, I don't know the configuration very well yet - so, unsure if this is the one of 3-4 interpreter paths to use
-        f"--python-interpreter-path={os.path.join(complete_pex_env.pex_root, requirements_venv_pex.venv_rel_dir)}",
+        f"--python-interpreter-path={requirements_venv_pex.python.argv0}",
+        *search_path_args,
     )
     result = await execute_process(
         Process(
@@ -192,6 +195,10 @@ async def pyrefly_typecheck_partition(
             immutable_input_digests={immutable_input_key: pyrefly_tool.digest},
             description=f"Run Pyrefly on {pluralize(len(roots_sources.files), 'file')}.",
             level=LogLevel.DEBUG,
+            cache_scope=getattr(
+                check_subsystem, "default_process_cache_scope", ProcessCacheScope.SUCCESSFUL
+            ),
+            append_only_caches=complete_pex_env.append_only_caches,
         ),
         **implicitly(),
     )
@@ -238,7 +245,7 @@ async def pyrefly_determine_partitions(
     )
 
 
-@rule(desc="Pyreflypecheck using Pyrefly", level=LogLevel.DEBUG)
+@rule(desc="Typecheck using Pyrefly", level=LogLevel.DEBUG)
 async def pyrefly_typecheck(
     request: PyreflyRequest,
     pyrefly: Pyrefly,

--- a/pants-plugins/experimental/pyrefly/rules_integration_test.py
+++ b/pants-plugins/experimental/pyrefly/rules_integration_test.py
@@ -1,0 +1,142 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from textwrap import dedent
+
+import pytest  # pants: no-infer-dep
+
+from experimental.pyrefly.register import rules as pyrefly_rules
+from experimental.pyrefly.rules import PyreflyFieldSet, PyreflyRequest
+from pants.backend.python import target_types_rules
+from pants.backend.python.target_types import (
+    PythonRequirementTarget,
+    PythonSourcesGeneratorTarget,
+    PythonSourceTarget,
+)
+from pants.core.goals.check import CheckResult, CheckResults
+from pants.engine.addresses import Address
+from pants.engine.rules import QueryRule
+from pants.engine.target import Target
+from pants.testutil.python_rule_runner import PythonRuleRunner
+
+PACKAGE = "src/python/myapp"
+
+GOOD_WITH_THIRDPARTY = dedent(
+    """\
+    import pydantic
+
+    class Foo(pydantic.BaseModel):
+        x: int
+    """
+)
+
+BAD_FILE = dedent(
+    """\
+    x: int = "not-an-int"
+    """
+)
+
+PYPROJECT_STRICT = dedent(
+    """\
+    [tool.pyrefly]
+    python-version = "3.11"
+    """
+)
+
+PYPROJECT = dedent(
+    """\
+    [tool.pyrefly]
+    python-version = "3.11"
+    permissive-ignores = true
+    """
+)
+
+
+@pytest.fixture
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
+        rules=[
+            *pyrefly_rules(),
+            *target_types_rules.rules(),
+            QueryRule(CheckResults, (PyreflyRequest,)),
+        ],
+        target_types=[
+            PythonRequirementTarget,
+            PythonSourcesGeneratorTarget,
+            PythonSourceTarget,
+        ],
+    )
+
+
+def run_pyrefly(
+    rule_runner: PythonRuleRunner,
+    targets: Iterable[Target],
+    *,
+    extra_args: Iterable[str] | None = None,
+) -> tuple[CheckResult, ...]:
+    rule_runner.set_options(
+        [
+            "--source-root-patterns=['src/python']",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    result = rule_runner.request(
+        CheckResults,
+        [PyreflyRequest(PyreflyFieldSet.create(tgt) for tgt in targets)],
+    )
+    return result.results
+
+
+def test_thirdparty_import_succeeds(rule_runner: PythonRuleRunner) -> None:
+    """Minimal repro: third-party imports must resolve inside the sandbox.
+
+    Without append_only_caches on the pyrefly Process, Pyrefly cannot query the
+    requirements venv interpreter and reports spurious missing-import errors.
+    """
+    rule_runner.write_files(
+        {
+            "BUILD": "python_requirement(name='pydantic', requirements=['pydantic>=2,<3'])",
+            "pyproject.toml": PYPROJECT,
+            f"{PACKAGE}/main.py": GOOD_WITH_THIRDPARTY,
+            f"{PACKAGE}/BUILD": "python_sources()",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="main.py"))
+    result = run_pyrefly(rule_runner, [tgt])
+    assert len(result) == 1
+    assert result[0].exit_code == 0
+    output = f"{result[0].stdout}\n{result[0].stderr}"
+    assert "missing-import" not in output.lower()
+    assert "0 errors" in output.lower()
+
+
+def test_type_error_fails(rule_runner: PythonRuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "pyproject.toml": PYPROJECT_STRICT,
+            f"{PACKAGE}/main.py": BAD_FILE,
+            f"{PACKAGE}/BUILD": "python_sources()",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="main.py"))
+    result = run_pyrefly(rule_runner, [tgt])
+    assert len(result) == 1
+    assert result[0].exit_code == 1
+
+
+def test_skip(rule_runner: PythonRuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": "python_requirement(name='pydantic', requirements=['pydantic>=2,<3'])",
+            "pyproject.toml": PYPROJECT,
+            f"{PACKAGE}/main.py": BAD_FILE,
+            f"{PACKAGE}/BUILD": "python_sources()",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="main.py"))
+    result = run_pyrefly(rule_runner, [tgt], extra_args=["--pyrefly-skip"])
+    assert not result

--- a/pants-plugins/experimental/pyrefly/subsystems.py
+++ b/pants-plugins/experimental/pyrefly/subsystems.py
@@ -23,19 +23,16 @@ class Pyrefly(TemplatedExternalTool):
     name = "Pyrefly"
     help = softwrap("""A fast type checker and language server for Python (https://github.com/facebook/pyrefly).""")
 
-    default_version = "0.47.0"
+    default_version = "1.0.0"
     default_known_versions = [
-        "0.47.0|linux_arm64|ff64d8c6191f6199423b96e1f29a9d52405fad49347880af7f9d1559c51176d3|112163992",
-        "0.47.0|linux_x86_64|0a84a30753622c0f988bbc650fe6e6307df57986cba1afea2e67e1d8c2e989fc|113266536",
-        "0.47.0|macos_arm64|494934686a7ecc2e589407bf8979795272aa8eb68abfea06f3643d6422d6ecce|22188776",
-        "0.47.0|macos_x86_64|e1d38aa61bcc4df1b9a1036db2b94ab24e24fbac53f674ef2b8e2ec326246d62|23746832",
+        "1.0.0|linux_arm64|0f4a075b510c56089f672c7283528398656fd0a54110d6836919ce34dbf15c0b|12611542",
+        "1.0.0|linux_x86_64|8b35318ba7377a621ff9d9ef77a443b6ad3cf065be566c84f5ae9c8318df5459|13141546",
+        "1.0.0|macos_arm64|f3c2277245677b0128099f4971ae11c9c4a4d9a39aad70444c2f79a9d64b6893|12156236",
+        "1.0.0|macos_x86_64|a152c7a775aa3088e7af5257330ba37d7d85337a0e85823b4dc2db556b7c39cf|12775069",
     ]
 
-    # TODO: Pyrefly only releases to PyPi
-    # TODO: https://github.com/facebook/pyrefly/issues/883
-    # Pulling from my super temporary repo... Uncompressed binaries - the Linux ones are > 100MB !?!?
     default_url_template = (
-        "https://github.com/sureshjoshi/pyrefly-binaries/releases/download/{version}/pyrefly-{platform}"
+        "https://github.com/facebook/pyrefly/releases/download/{version}/pyrefly-{platform}.tar.gz"
     )
 
     default_url_platform_mapping = {
@@ -46,7 +43,7 @@ class Pyrefly(TemplatedExternalTool):
     }
 
     def generate_exe(self, plat: Platform) -> str:
-        return f"pyrefly-{self.default_url_platform_mapping[plat.value]}"
+        return "pyrefly"
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--version")


### PR DESCRIPTION
- Upgrade default Pyrefly version to 1.0.0 with official GitHub release binaries.
- Fix sandbox import resolution by mounting the PEX venv via `append_only_caches`.
- Inject Pants source roots as `--search-path` so users need not hard-code them in `pyproject.toml`.
- Fix a typo in the rule description: "Pyreflypecheck using Pyrefly" -> "Typecheck using Pyrefly"

Fixes: #115

I've tested this plugin version on my pants repo and it works well. All pyrefly config is done via `pyproject.toml`.

## AI Disclosure

Claude Code and Cursor were used to diagnose the problem, write the fixes with my input, and write the new test.

## Self-contained repro for dependency issues

Most of the charges are fairly straightforward, except for the way that we wire up the PEX venv via append_only_caches. That change was motivated by an issue that's easy to demonstrate with this self-contained shell script:

```
#!/usr/bin/env bash
# Reproduces: robotpajamas.pants.pyrefly missing append_only_caches on its
# Process call → pants check reports "Failed to query interpreter ... Permission
# denied (os error 13)" and falls back to the default Python env, so all
# third-party imports appear as missing-import errors.
set -euo pipefail

DIR=$(mktemp -d)
trap 'rm -rf "$DIR"' EXIT
echo "$DIR"
cd "$DIR"

cat > pants.toml <<'TOML'
[GLOBAL]
pants_version = "2.32.0"
plugins = ["robotpajamas.pants.pyrefly"]
backend_packages = ["pants.backend.python", "experimental.pyrefly"]

[python]
interpreter_constraints = ["CPython==3.14.*"]
enable_resolves = true
default_resolve = "default"

[python.resolves]
default = "default.lock"

[source]
root_patterns = ["src/python"]
TOML

cat > pyproject.toml <<'TOML'
[project]
name = "repro"
version = "0.0.0"
requires-python = ">=3.11"
dependencies = ["pydantic>=2"]

[tool.pyrefly]
python-version = "3.11"
search-path = ["src/python"]
permissive-ignores = true
TOML

cat > BUILD <<'BUILD'
python_requirements(
  name="python",
  source="pyproject.toml",
  resolve="default",
)
BUILD

mkdir -p src/python/myapp
cat > src/python/myapp/BUILD <<'EOF'
python_sources()
EOF

cat > src/python/myapp/main.py <<'PY'
import pydantic

class Foo(pydantic.BaseModel):
    x: int
PY

pants generate-lockfiles --resolve=default
pants check src/python/myapp/::
```